### PR TITLE
Restore use of vmap+jvp in jacfwd

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.1.2"
+current_version = "v0.1.3"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # sparsejac: Efficient forward- and reverse-mode sparse Jacobians using Jax.
-`v0.1.2`
+`v0.1.3`
 
 Sparse Jacobians are frequently encountered in the simulation of physical systems. Jax tranformations `jacfwd` and `jacrev` make it easy to compute dense Jacobians, but these are wasteful when the Jacobian is sparse. `sparsejac` provides a function to more efficiently compute the Jacobian if its sparsity is known. It makes use of the recently-introduced `jax.experimental.sparse` module.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "sparsejac"
-version = "v0.1.2"
+version = "v0.1.3"
 description = "Efficient forward- and reverse-mode sparse Jacobians using Jax."
 keywords = ["jax", "jacobian", "sparse"]
 readme = "README.md"

--- a/src/sparsejac/__init__.py
+++ b/src/sparsejac/__init__.py
@@ -1,6 +1,6 @@
 """sparsejac - Efficient forward- and reverse-mode sparse Jacobians using Jax."""
 
-__version__ = "v0.1.2"
+__version__ = "v0.1.3"
 __author__ = "Martin Schubert <mfschubert@gmail.com>"
 
 from sparsejac.sparsejac import jacfwd as jacfwd

--- a/src/sparsejac/sparsejac.py
+++ b/src/sparsejac/sparsejac.py
@@ -1,6 +1,5 @@
 """Defines functions for efficient computation of sparse Jacobians."""
 
-import functools
 from typing import Any, Callable, Tuple, Union
 
 import jax

--- a/src/sparsejac/sparsejac.py
+++ b/src/sparsejac/sparsejac.py
@@ -1,5 +1,6 @@
 """Defines functions for efficient computation of sparse Jacobians."""
 
+import functools
 from typing import Any, Callable, Tuple, Union
 
 import jax
@@ -195,11 +196,23 @@ def jacfwd(
             return fn(*args_with_x)
 
         if has_aux:
-            _, jvp_fn, aux = jax.linearize(_fn, x, has_aux=True)
-        else:
-            _, jvp_fn = jax.linearize(_fn, x, has_aux=False)
 
-        compressed_jac_transpose = jax.vmap(jvp_fn, in_axes=1)(basis)
+            def _jvp_fn_with_aux(tangents: jnp.ndarray) -> Tuple[jnp.ndarray, Any]:
+                _, tangents_out, aux = jax.jvp(_fn, (x,), (tangents,), has_aux=True)
+                return tangents_out, aux
+
+            compressed_jac_transpose, aux = jax.vmap(
+                _jvp_fn_with_aux, in_axes=1, out_axes=(0, None)
+            )(basis)
+
+        else:
+
+            def _jvp_fn(tangents: jnp.ndarray) -> jnp.ndarray:
+                _, tangents_out = jax.jvp(_fn, (x,), (tangents,), has_aux=False)
+                return tangents_out
+
+            compressed_jac_transpose = jax.vmap(_jvp_fn, in_axes=1)(basis)
+
         compressed_jac = compressed_jac_transpose.T
         if compressed_jac.shape != (sparsity.shape[0], ncolors):
             raise ValueError(


### PR DESCRIPTION
A closer reading of the `jax.linearize` documentation suggests the original vmap + jvp is a better way to go. This is supported by a quick performance test. Here we restore the original implementation.